### PR TITLE
🚀 Add Framer Motion to Motion Migration Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,107 @@
+# Framer Motion to Motion Migration Tool
+
+A simple, automated migration script I created to upgrade projects from `framer-motion` to the new `motion` package.
+
+## My Problem
+
+When I was excited to upgrade to Motion (the successor to Framer Motion), I quickly realized the official documentation was seriously missing migration tooling. I had used framer-motion in a lot of different places across my projects, and manually updating imports in dozens of files seemed like a nightmare.
+
+After struggling with this across several of my Node.js projects, I decided to write a script to automate the process.
+
+## My Solution
+
+This script automatically scans your project and converts all `framer-motion` imports to `motion/react` imports. I've tested it on several of my projects and it handles various import patterns:
+
+- Named imports: `import { motion, AnimatePresence } from 'framer-motion'`
+- Namespace imports: `import * as FramerMotion from 'framer-motion'`
+- Default imports: `import motion from 'framer-motion'`
+
+## Installation & Usage
+
+### Prerequisites
+
+First, update your package.json dependencies:
+```bash
+npm uninstall framer-motion
+npm install motion
+```
+
+### Running the Migration
+
+1. **Download the script** to your project root:
+   ```bash
+   curl -O https://raw.githubusercontent.com/yourusername/motion-migration-nextjs/main/motion-migrate.js
+   ```
+
+2. **Preview changes** (I always recommend this first):
+   ```bash
+   node motion-migrate.js --dry
+   ```
+
+3. **Run the migration**:
+   ```bash
+   node motion-migrate.js
+   ```
+
+4. **Clean up** (optional):
+   ```bash
+   rm motion-migrate.js
+   ```
+
+## What It Does
+
+### Files Processed
+- `.js`, `.jsx`, `.ts`, `.tsx` files
+- Recursively scans your entire project
+- Skips `node_modules`, `.next`, `dist`, `.git` directories
+
+### Import Transformations
+
+| Before | After |
+|--------|--------|
+| `import { motion } from 'framer-motion'` | `import { motion } from 'motion/react'` |
+| `import * as Motion from 'framer-motion'` | `import * as Motion from 'motion/react'` |
+| `import motion from 'framer-motion'` | `import motion from 'motion/react'` |
+
+### Example Output
+
+**Dry run mode:**
+```
+🔍 Previewing changes...
+📝 Would update: src/components/Header.tsx
+📝 Would update: src/pages/index.tsx
+📝 Would update: src/components/Modal.jsx
+
+💡 Dry run complete - 3 file(s) would be updated.
+```
+
+**Migration mode:**
+```
+🔍 Scanning and migrating...
+✅ Updated: src/components/Header.tsx
+✅ Updated: src/pages/index.tsx
+✅ Updated: src/components/Modal.jsx
+
+🎉 Migration complete - 3 file(s) updated!
+```
+
+## Safety Features
+
+I built in several safety features based on my experience:
+
+- **Dry run mode**: Always preview changes before applying them
+- **Targeted processing**: Only processes relevant file types
+- **Directory filtering**: Automatically skips common build/dependency directories
+- **Backup recommended**: Always commit your changes before running any migration script
+
+## Why I'm Sharing This
+
+I felt like the Motion package website and documentation was seriously missing out on providing migration tooling. Since I had to solve this problem for my own projects, I figured other developers might benefit from this simple script.
+
+## Contributing
+
+Found an edge case or have suggestions? Please open an issue or submit a pull request!
+
+## License
+
+MIT License - feel free to use this in your projects. 

--- a/motion-migrate.js
+++ b/motion-migrate.js
@@ -1,0 +1,86 @@
+/**
+ * Migrates framer-motion imports to motion/react
+ * 
+ * Usage:
+ *   node motion-migrate.js        # run migration
+ *   node motion-migrate.js --dry  # preview changes
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Check if dry run mode
+const DRY = process.argv.includes('--dry');
+
+// File extensions to process
+const EXTS = ['.js', '.jsx', '.ts', '.tsx'];
+
+// Directories to skip
+const SKIP_DIRS = new Set(['node_modules', '.next', 'dist', '.git']);
+
+// Migration rules
+const RULES = [
+    {
+        re: /import\s*{\s*([^}]+)\s*}\s*from\s*['"]framer-motion['"]/g,
+        sub: 'import { $1 } from \'motion/react\''
+    },
+    {
+        re: /import\s+\*\s+as\s+(\w+)\s+from\s*['"]framer-motion['"]/g,
+        sub: 'import * as $1 from \'motion/react\''
+    },
+    {
+        re: /import\s+(\w+)\s+from\s*['"]framer-motion['"]/g,
+        sub: 'import $1 from \'motion/react\''
+    }
+];
+
+function isTargetFile(file) {
+    return EXTS.includes(path.extname(file));
+}
+
+function walk(dir, files = []) {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+        if (entry.isDirectory()) {
+            if (!SKIP_DIRS.has(entry.name)) {
+                walk(path.join(dir, entry.name), files);
+            }
+        } else if (entry.isFile() && isTargetFile(entry.name)) {
+            files.push(path.join(dir, entry.name));
+        }
+    }
+    return files;
+}
+
+// Main execution
+console.log(DRY ? '🔍 Previewing changes...' : '🔍 Scanning and migrating...');
+
+const allFiles = walk(process.cwd());
+let changed = 0;
+
+allFiles.forEach(file => {
+    let src = fs.readFileSync(file, 'utf8');
+    let hit = false;
+
+    RULES.forEach(({ re, sub }) => {
+        if (re.test(src)) {
+            src = src.replace(re, sub);
+            hit = true;
+        }
+    });
+
+    if (hit) {
+        if (DRY) {
+            console.log(`📝 Would update: ${file}`);
+        } else {
+            fs.writeFileSync(file, src);
+            console.log(`✅ Updated: ${file}`);
+        }
+        changed++;
+    }
+});
+
+console.log(DRY
+    ? `\n💡 Dry run complete - ${changed} file(s) would be updated.`
+    : `\n🎉 Migration complete - ${changed} file(s) updated!`
+);


### PR DESCRIPTION
## 🎯 Problem Solved

When I got excited about upgrading to **Motion** (successor to Framer Motion), I quickly realised the official documentation was seriously missing migration tooling! 

I had `framer-motion` imports scattered across multiple files in my projects - manually updating them seemed like a nightmare!

## 💡 My Solution

I created this automated migration script that I've tested across several of my Node.js projects. It handles all common import patterns and makes the framer-motion → motion transition seamless.

## ✨ What's Included

- **🔧 motion-migrate.js** - Automated migration script
- **📖 Comprehensive README** - Clear setup and usage instructions  
- **🛡️ Safety features** - Dry-run mode to preview changes
- **🎯 Smart processing** - Only targets relevant files, skips build dirs

## 🔄 Import Transformations

The script handles these patterns:
- `import { motion } from 'framer-motion'` → `import { motion } from 'motion/react'`
- `import * as Motion from 'framer-motion'` → `import * as Motion from 'motion/react'`  
- `import motion from 'framer-motion'` → `import motion from 'motion/react'`

## 🚦 Simple Usage

```bash
# Always preview first!
node motion-migrate.js --dry

# Run the migration
node motion-migrate.js
```

## 🧪 Battle-Tested

- ✅ React projects
- ✅ Next.js apps  
- ✅ TypeScript codebases
- ✅ Mixed JS/TS projects

## 🎁 Why?

The Motion package docs are missing this crucial tooling. Since I solved this problem for my own projects, I figured the community could benefit too!

This script has saved me hours of manual work - hopefully it helps others migrate without the headache! 🎉

## 🔍 Files Changed

- `motion-migrate.js` - The migration script
- `README.md` - Documentation and usage guide